### PR TITLE
Search clear

### DIFF
--- a/web/src/actions/search.js
+++ b/web/src/actions/search.js
@@ -1,6 +1,7 @@
 /*
  * Action Types
  */
+export const SEARCH_CLEAR = 'SEARCH_CLEAR';
 export const SEARCH_SUBMIT = 'SEARCH_SUBMIT';
 export const SEARCH_RESULTS = 'SEARCH_RESULTS';
 
@@ -15,4 +16,8 @@ export const submit = (qry) => ({
 export const results = (payload) => ({
   type: SEARCH_RESULTS,
   payload
+});
+
+export const clear = () => ({
+  type: SEARCH_CLEAR
 });

--- a/web/src/components/Home.js
+++ b/web/src/components/Home.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import Results from './SearchResults';
+import Results from '../containers/SearchResults';
 import { Link } from 'react-router-dom';
 
-export default function Home({ qry, handleSubmit, handleChange, results, isLoading }) {
+export default function Home({ qry, handleSubmit, handleChange, isLoading }) {
   return (<div className="container-fluid">
     <form onSubmit={handleSubmit(qry)}>
       <div className="row mt-5">
@@ -24,6 +24,6 @@ export default function Home({ qry, handleSubmit, handleChange, results, isLoadi
         </Link>
       </div>
     </form>
-    <Results results={results} />
+    <Results />
   </div>);
 }

--- a/web/src/components/SearchResults.js
+++ b/web/src/components/SearchResults.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 
-export default function SearchResults({ results }) {
+export default function SearchResults({ results, clearSearch }) {
   let search = <div />;
   if(results.length) {
     search = (<div>
       <h4>Search Results</h4>
       <ul className="list-group list-group-flush">
         {results.map(result => <li className="list-group-item" key={result.id}>
-          <Link to={`/topics/${result.id}`}>{result.name}</Link>
+          <Link onClick={clearSearch} to={`/topics/${result.id}`}>{result.name}</Link>
         </li>)}
       </ul>
     </div>);

--- a/web/src/components/SearchResults.js
+++ b/web/src/components/SearchResults.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 
-export default function SearchResults({ results, clearSearch }) {
-  let search = <div />;
-  if(results.length) {
-    search = (<div>
-      <h4>Search Results</h4>
-      <ul className="list-group list-group-flush">
-        {results.map(result => <li className="list-group-item" key={result.id}>
-          <Link onClick={clearSearch} to={`/topics/${result.id}`}>{result.name}</Link>
-        </li>)}
-      </ul>
-    </div>);
+export default function SearchResults({ results, clearSearch, hasSubmit }) {
+  if(!hasSubmit) {
+    // The case when nothing has been sent or received from the server.
+    return <div />;
   }
-  return search;
+
+  if(!results.length) {
+    return <h4>No results found</h4>;
+  }
+
+  return (<div>
+    <h4>Search Results</h4>
+    <ul className="list-group list-group-flush">
+      {results.map(result => <li className="list-group-item" key={result.id}>
+        <Link onClick={clearSearch} to={`/topics/${result.id}`}>{result.name}</Link>
+      </li>)}
+    </ul>
+  </div>);
 }

--- a/web/src/containers/SearchResults.js
+++ b/web/src/containers/SearchResults.js
@@ -4,7 +4,8 @@ import SearchResults from '../components/SearchResults';
 import { clear as searchClear } from '../actions/search';
 
 const mapStateToProps = (state, ownProps) => ({
-  results: state.search.results
+  results: state.search.results,
+  hasSubmit: state.search.hasSubmit
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/web/src/containers/SearchResults.js
+++ b/web/src/containers/SearchResults.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+
+import SearchResults from '../components/SearchResults';
+import { clear as searchClear } from '../actions/search';
+
+const mapStateToProps = (state, ownProps) => ({
+  results: state.search.results
+});
+
+const mapDispatchToProps = dispatch => ({
+  clearSearch: () => {
+    // This is a hacky way to clear search results after navigating away
+    // because the react-router-redux at this time is all sorts of broken
+    setTimeout(() => dispatch(searchClear()), 200);
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResults);

--- a/web/src/reducers/search.js
+++ b/web/src/reducers/search.js
@@ -2,7 +2,8 @@ import * as search from '../actions/search';
 
 const initialState = {
   results: [],
-  qry: ''
+  qry: '',
+  hasSubmit: false
 };
 
 export default function reducer(state = initialState, action) {
@@ -12,7 +13,7 @@ export default function reducer(state = initialState, action) {
     case search.SEARCH_SUBMIT:
       return Object.assign({}, state, {qry: ""});
     case search.SEARCH_RESULTS:
-      return Object.assign({}, state, {results: action.payload});
+      return Object.assign({}, state, {results: action.payload, hasSubmit: true});
     default:
       return state;
   }

--- a/web/src/reducers/search.js
+++ b/web/src/reducers/search.js
@@ -1,14 +1,17 @@
-import { SEARCH_SUBMIT, SEARCH_RESULTS } from '../actions/search';
+import * as search from '../actions/search';
 
 const initialState = {
-  results: []
+  results: [],
+  qry: ''
 };
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
-    case SEARCH_SUBMIT:
+    case search.SEARCH_CLEAR:
+      return initialState;
+    case search.SEARCH_SUBMIT:
       return Object.assign({}, state, {qry: ""});
-    case SEARCH_RESULTS:
+    case search.SEARCH_RESULTS:
       return Object.assign({}, state, {results: action.payload});
     default:
       return state;


### PR DESCRIPTION
#### Issue
Need search to clear after you navigate away.

#### Solution
A hack.  Listen to clicks on the topic links and clear search then.  The proper way now is to use `react-router-redux` to listen to navigation events.  But it's super broken so that was super painful.

Additionally, it now says there are no results if you search and but there aren't any results.

